### PR TITLE
Minor naming fix

### DIFF
--- a/_hugo/config.toml
+++ b/_hugo/config.toml
@@ -8,11 +8,11 @@ theme = "vanilla-base-theme"
   mainIcon = "/img/vanilla-logo.png"
 
 [[params.social]]
-    title = "Play store"
+    title = "Google Play"
     url = "https://play.google.com/store/apps/details?id=ch.blinkenlights.android.vanilla"
 [[params.social]]
     title = "F-Droid"
     url = "https://f-droid.org/repository/browse/?fdid=ch.blinkenlights.android.vanilla"
 [[params.social]]
-    title = "github"
+    title = "GitHub"
     url = "https://github.com/vanilla-music/vanilla"

--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@
         <div class="description">A small, fast and free (GPLv3) music player for Android</div>
         <div class="buttonbox">
        
-            <a href="https://play.google.com/store/apps/details?id=ch.blinkenlights.android.vanilla" class="btn btn-vanilla btn-lg"><i class="icon-play store"></i> <span class="network-name">Play store</span></a>
+            <a href="https://play.google.com/store/apps/details?id=ch.blinkenlights.android.vanilla" class="btn btn-vanilla btn-lg"><i class="icon-play store"></i> <span class="network-name">Google Play</span></a>
         
             <a href="https://f-droid.org/repository/browse/?fdid=ch.blinkenlights.android.vanilla" class="btn btn-vanilla btn-lg"><i class="icon-f-droid"></i> <span class="network-name">F-Droid</span></a>
         
-            <a href="https://github.com/vanilla-music/vanilla" class="btn btn-vanilla btn-lg"><i class="icon-github"></i> <span class="network-name">github</span></a>
+            <a href="https://github.com/vanilla-music/vanilla" class="btn btn-vanilla btn-lg"><i class="icon-github"></i> <span class="network-name">GitHub</span></a>
         
         </div>
       </div>


### PR DESCRIPTION
Use original names for "github" and "Play store"